### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,21 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: oca-fix-manifest-website
+        name: "OCA Fix Manifest Website"  
+        entry: oca-fix-manifest-website  
+        language: system                
+        files: \.py$                    
+        types: [file]                   
+        exclude: |
+          (?x)^(
+            # Excluir todos los módulos personalizados fuera del patrón OCA
+            alda_.*|custom_.*|local_.*|
+            # Otros paths del repo que no queremos tocar
+            connector_docuware/|
+            custom_login_by_token/|
+            purchase_portal/
+          )
   - repo: https://github.com/oca/maintainer-tools
     rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,19 +39,18 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
       - id: oca-fix-manifest-website
-        name: "OCA Fix Manifest Website"  
-        entry: oca-fix-manifest-website  
-        language: system                
-        files: \.py$                    
-        types: [file]                   
+        name: "OCA Fix Manifest Website"
+        entry: oca-fix-manifest-website
+        language: system
+        files: ^[^/]+/__manifest__\.py$
         exclude: |
           (?x)^(
-            # Excluir todos los módulos personalizados fuera del patrón OCA
-            alda_.*|custom_.*|local_.*|
-            # Otros paths del repo que no queremos tocar
-            connector_docuware/__manifest__.py|
-            custom_login_by_token/__manifest__.py|
-            purchase_portal/__manifest__.py
+            alda_.*|
+            custom_.*|
+            local_.*|
+            connector_docuware/|
+            custom_login_by_token/|
+            purchase_portal/
           )
   - repo: https://github.com/oca/maintainer-tools
     rev: 9a170331575a265c092ee6b24b845ec508e8ef75

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,9 +49,9 @@ repos:
             # Excluir todos los módulos personalizados fuera del patrón OCA
             alda_.*|custom_.*|local_.*|
             # Otros paths del repo que no queremos tocar
-            connector_docuware/|
-            custom_login_by_token/|
-            purchase_portal/
+            connector_docuware/__manifest__.py|
+            custom_login_by_token/__manifest__.py|
+            purchase_portal/__manifest__.py
           )
   - repo: https://github.com/oca/maintainer-tools
     rev: 9a170331575a265c092ee6b24b845ec508e8ef75


### PR DESCRIPTION
### Corrige el error de validación del website.
**Antes:**  obliga a tener la website de oca/pms obligatorio 
**Ahora:** Todos los módulos cuyo nombre comience con alda_, custom_ o local_ permitirán website distintos de oca.