### PR TITLE
[ADD] account_payment_grouped_output: Agrupación de pagos pendientes

### DIFF
--- a/account_payment_grouped_output/__init__.py
+++ b/account_payment_grouped_output/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_grouped_output/__manifest__.py
+++ b/account_payment_grouped_output/__manifest__.py
@@ -1,0 +1,14 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Account Payment - Generate grouped moves",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Comunitea",
+    "website": "https://www.comunitea.com",
+    "category": "Banking addons",
+    "depends": ["account"],
+    "data": ["data/ir_cron.xml",
+             "views/account_journal_view.xml"],
+    "installable": True,
+}

--- a/account_payment_grouped_output/data/ir_cron.xml
+++ b/account_payment_grouped_output/data/ir_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+
+    <record id="ir_cron_group_outstanding_payments" model="ir.cron">
+      <field name="name">Group Outstanding Payments</field>
+      <field name="model_id" ref="account.model_account_journal"/>
+      <field name="state">code</field>
+      <field name="code">model._cron_group_outstanding_payments()</field>
+      <field name="interval_number">1</field>
+      <field name="interval_type">days</field>
+      <field name="numbercall">-1</field>
+      <field name="active">True</field>
+    </record>
+
+</odoo>

--- a/account_payment_grouped_output/i18n/es.po
+++ b/account_payment_grouped_output/i18n/es.po
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_payment_grouped_output
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-12-23 17:46+0000\n"
+"PO-Revision-Date: 2025-12-23 17:46+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_grouped_output
+#. odoo-python
+#: code:addons/account_payment_grouped_output/models/account_journal.py:0
+#, python-format
+msgid "Auto grouped payments %s - %s"
+msgstr "Pagos agrupados automáticamente %s - %s"
+
+#. module: account_payment_grouped_output
+#: model:ir.model.fields,field_description:account_payment_grouped_output.field_account_journal__automatic_group_payments_to_reconcile
+msgid "Automatic Group Payments to Reconcile"
+msgstr "Pagos automáticos agrupados para conciliar"
+
+#. module: account_payment_grouped_output
+#: model:ir.model.fields,field_description:account_payment_grouped_output.field_account_journal__grace_days_to_group_payments
+msgid "Grace Days to Group Payments"
+msgstr "Días de gracia para agrupar pagos"
+
+#. module: account_payment_grouped_output
+#: model:ir.actions.server,name:account_payment_grouped_output.ir_cron_group_outstanding_payments_ir_actions_server
+#: model:ir.cron,cron_name:account_payment_grouped_output.ir_cron_group_outstanding_payments
+msgid "Group Outstanding Payments"
+msgstr "Agrupar pagos pendientes"
+
+#. module: account_payment_grouped_output
+#. odoo-python
+#: code:addons/account_payment_grouped_output/models/account_journal.py:0
+#, python-format
+msgid "Grouped pending %s"
+msgstr "Pendientes agrupados %s"
+
+#. module: account_payment_grouped_output
+#: model:ir.model.fields,help:account_payment_grouped_output.field_account_journal__automatic_group_payments_to_reconcile
+msgid ""
+"If enabled, payments made through this journal will be automatically grouped"
+" for reconciliation days after of creation."
+msgstr "Si está habilitado, los pagos realizados a través de este diario se agruparán automáticamente para la conciliación días después de su creación."
+
+#. module: account_payment_grouped_output
+#: model:ir.model,name:account_payment_grouped_output.model_account_journal
+msgid "Journal"
+msgstr "Diario"
+
+#. module: account_payment_grouped_output
+#: model:ir.model.fields,help:account_payment_grouped_output.field_account_journal__grace_days_to_group_payments
+msgid "Number of days to wait before grouping payments for reconciliation."
+msgstr "Número de días a esperar antes de agrupar los pagos para la conciliación."

--- a/account_payment_grouped_output/models/__init__.py
+++ b/account_payment_grouped_output/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_journal

--- a/account_payment_grouped_output/models/account_journal.py
+++ b/account_payment_grouped_output/models/account_journal.py
@@ -1,0 +1,148 @@
+from datetime import timedelta
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    automatic_group_payments_to_reconcile = fields.Boolean(
+        string="Automatic Group Payments to Reconcile",
+        help="If enabled, payments made through this journal will be automatically grouped for reconciliation days after of creation.",
+        default=False,
+    )
+    grace_days_to_group_payments = fields.Integer(
+        string="Grace Days to Group Payments",
+        help="Number of days to wait before grouping payments for reconciliation.",
+        default=2,
+    )
+
+    @api.model
+    def _cron_group_outstanding_payments(self):
+        journals = self.search([("automatic_group_payments_to_reconcile", "=", True)])
+        for journal in journals:
+            try:
+                journal._group_outstanding_payments_for_journal()
+            except Exception as e:
+                # No aborta el cron por un diario con error
+                self.env.cr.rollback()
+                self.env["ir.logging"].create({
+                    "name": "group_outstanding_payments",
+                    "type": "server",
+                    "dbname": self._cr.dbname,
+                    "level": "ERROR",
+                    "message": str(e),
+                    "path": __name__,
+                    "func": "_cron_group_outstanding_payments",
+                    "line": 0,
+                })
+
+    def _group_outstanding_payments_for_journal(self):
+        self.ensure_one()
+        # Cuentas de pendientes (company-level fallbacks)
+        debit_acc = self.company_id.account_journal_payment_debit_account_id
+        credit_acc = self.company_id.account_journal_payment_credit_account_id
+        account_ids = [acc.id for acc in (debit_acc, credit_acc) if acc]
+        if not account_ids:
+            return
+
+        today = fields.Date.context_today(self)
+        cutoff = today - timedelta(days=self.grace_days_to_group_payments or 0)
+
+        aml_obj = self.env["account.move.line"]
+        domain = [
+            ("journal_id", "=", self.id),
+            ("payment_id", "!=", False),      # líneas procedentes de pagos
+            ("reconciled", "=", False),
+            ("account_id", "in", account_ids),
+            ("parent_state", "=", "posted"),
+            ("date", "=", cutoff),
+        ]
+        amls = aml_obj.search(domain, order="date,id")
+        if not amls:
+            return
+
+        # Agrupar por fecha y cuenta (no mezclamos inbound/outbound)
+        groups = {}
+        for aml in amls:
+            key = (aml.date, aml.account_id.id)
+            groups.setdefault(key, self.env["account.move.line"])
+            groups[key] += aml
+
+        for (gdate, gacc_id), lines in groups.items():
+            self._create_grouping_move_for_lines(gdate, lines)
+
+    def _create_grouping_move_for_lines(self, gdate, amls):
+        # Construye el asiento: líneas inversas por pago + línea de contrapartida agregada sin partner
+        Move = self.env["account.move"]
+        vals = {
+            "date": gdate,
+            "journal_id": self.id,
+            "ref": _("Auto grouped payments %s - %s") % (self.name, fields.Date.to_string(gdate)),
+            "line_ids": [],
+        }
+
+        total_debit = 0.0
+        total_credit = 0.0
+        reverse_names = []
+
+        for aml in amls:
+            amount = abs(aml.balance)
+            # Línea inversa en la misma cuenta para poder conciliar individualmente
+            if aml.balance > 0:  # original es débito -> creamos un crédito
+                debit = 0.0
+                credit = amount
+            else:                # original es crédito -> creamos un débito
+                debit = amount
+                credit = 0.0
+
+            line_name = "Reverse:%s" % aml.id
+            reverse_names.append(line_name)
+
+            vals["line_ids"].append((0, 0, {
+                "name": line_name,
+                "account_id": aml.account_id.id,
+                "partner_id": aml.partner_id.id or False,  # opcional; ayuda a conciliar
+                "debit": debit,
+                "credit": credit,
+                "currency_id": aml.currency_id.id or False,
+                "amount_currency": aml.currency_id and (-aml.amount_currency) or 0.0,
+                "date_maturity": aml.date_maturity or aml.date,
+            }))
+
+            total_debit += debit
+            total_credit += credit
+
+        # Línea de contrapartida agregada en la misma cuenta, sin partner (queda abierta para conciliar con el extracto)
+        diff = round(total_debit - total_credit, 2)
+        if abs(diff) < 0.00001:
+            # Nada que balancear (caso raro). Evitar asiento desbalanceado.
+            return
+
+        if diff > 0:  # sobra débito -> añadir crédito
+            bal_debit = 0.0
+            bal_credit = abs(diff)
+        else:         # sobra crédito -> añadir débito
+            bal_debit = abs(diff)
+            bal_credit = 0.0
+
+        # Misma cuenta de pendientes, sin partner
+        vals["line_ids"].append((0, 0, {
+            "name": _("Grouped pending %s") % fields.Date.to_string(gdate),
+            "account_id": amls[0].account_id.id,
+            "partner_id": False,
+            "debit": bal_debit,
+            "credit": bal_credit,
+            "currency_id": amls[0].currency_id.id,
+            "amount_currency": -1 * diff,
+            "date_maturity": gdate,
+        }))
+
+        move = Move.create(vals)
+        move.action_post()
+
+        # Conciliar cada pago con su línea inversa; la línea agregada queda abierta
+        for aml in amls:
+            rev = move.line_ids.filtered(lambda l: l.name == ("Reverse:%s" % aml.id))
+            if rev:
+                (aml + rev).reconcile()

--- a/account_payment_grouped_output/views/account_journal_view.xml
+++ b/account_payment_grouped_output/views/account_journal_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_account_journal_form_grouped_payments" model="ir.ui.view">
+      <field name="name">account.journal.form.grouped.payments</field>
+      <field name="model">account.journal</field>
+      <field name="inherit_id" ref="account.view_account_journal_form"/>
+      <field name="arch" type="xml">
+        <!-- Inserta el bloque justo después del campo 'type' -->
+        <xpath expr="//field[@name='type']" position="after">
+            <field name="automatic_group_payments_to_reconcile" attrs="{'invisible': [('type', 'not in', ['bank', 'cash'])]}"/>
+            <field name="grace_days_to_group_payments"
+                   attrs="{'invisible': [('automatic_group_payments_to_reconcile','=',False)]}"/>
+        </xpath>
+      </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Hola, 

Módulo que permite agrupar apuntes en cuentas de pago/cobros pendientes en un único asiento para facilitar su conciliación. La configuración se hace por diario, en el diario de banco o caja que interese hay que marcar "Pagos automáticos agrupados para conciliar" y a continuación indicar en "Días de gracia para agrupar pagos" los días hacia atrás donde va a buscar apuntes en cuentas de pendientes sin conciliar. 
Por otra parte hay un cron diario, donde habría que indicar la hora de ejcución.

Busca en el día concreto que corresponda según las fecha de ejecución y los días de gracia, de cara a probarlo.